### PR TITLE
A temporary workaround for a bug

### DIFF
--- a/constant.cs
+++ b/constant.cs
@@ -27,7 +27,7 @@
 		public const int threshold_length2match_offset = 1280;
 		public const int threshold_length3match_offset = 32000;
 		public const int threshold_offset = 65024;
-		public const int threshold_greedy_length = 255;
+		public const int threshold_greedy_length = 65535; //255; a workaround for a bug that kills compression on some highly compressible files
 		public const int threshold_gap_length = 24;
 
 


### PR DESCRIPTION
On some highly compressible files instead of encoding long runs of zeros as 0, then match with a -1 offset, the compressor chose to encode each zero in the run individually, using the 7-bit bytematch command with zero offset. This modification disables the bug.